### PR TITLE
Move changelogger type to config

### DIFF
--- a/.changelogger.yml.example
+++ b/.changelogger.yml.example
@@ -4,3 +4,11 @@ groups:
   - Module B
   - Module C
 
+#  You can use custom types, which are used instead of the default types.
+#  This makes it possible to introduce new types, remove type, which are
+#  not needed or even translate them into your language.
+#  The type `ignore: No Changelog` is added to your list if no `ignore` type
+#  is provided to allow empty changelogs.
+types:
+  added: New Feature
+  fixed: Bug fix

--- a/app/ChangeloggerConfig.php
+++ b/app/ChangeloggerConfig.php
@@ -103,4 +103,28 @@ class ChangeloggerConfig
 
         return $keyA <=> $keyB;
     }
+
+    /**
+     * Get list of types.
+     *
+     * Return default types declared in config/changelogger.php or
+     * use custom types from .changelogger.yml.
+     *
+     * @return array
+     */
+    public function getTypes(): array {
+        $types = null;
+        $defaultTypes = config('changelogger.types');
+
+        if ($this->config->has('types')) {
+            $types = $this->config->get('types');
+
+            if (! isset($types['ignore'])) {
+                $types['ignore'] = 'No Changelog';
+            }
+        }
+
+
+        return $types !== null ? array_flip($types) : $defaultTypes;
+    }
 }

--- a/app/Types.php
+++ b/app/Types.php
@@ -9,9 +9,9 @@ class Types
 
     private $types;
 
-    public function __construct()
+    public function __construct(ChangeloggerConfig $config)
     {
-        $this->types = config('changelogger.types');
+        $this->types = $config->getTypes();
     }
 
     /**

--- a/app/Types.php
+++ b/app/Types.php
@@ -10,6 +10,7 @@ class Types
     private $types = [
         'New feature'             => 'added',
         'Bug fix'                 => 'fixed',
+        'Hotfix'                  => 'hotfix',
         'Feature change'          => 'changed',
         'New deprecation'         => 'deprecated',
         'Feature removal'         => 'removed',

--- a/app/Types.php
+++ b/app/Types.php
@@ -7,19 +7,12 @@ use RuntimeException;
 class Types
 {
 
-    private $types = [
-        'New feature'             => 'added',
-        'Bug fix'                 => 'fixed',
-        'Hotfix'                  => 'hotfix',
-        'Feature change'          => 'changed',
-        'New deprecation'         => 'deprecated',
-        'Feature removal'         => 'removed',
-        'Security fix'            => 'security',
-        'Performance improvement' => 'performance',
-        'Other'                   => 'other',
-        'No Changelog'            => 'ignore',
-    ];
+    private $types;
 
+    public function __construct()
+    {
+        $this->types = config('changelogger.types');
+    }
 
     /**
      * Find name of a given type.

--- a/changelogs/unreleased/2020-03-11-111018-addNewTypeHotfix.yml
+++ b/changelogs/unreleased/2020-03-11-111018-addNewTypeHotfix.yml
@@ -1,0 +1,4 @@
+title: 'add new Type ''Hotfix'''
+type: other
+author: 'Christopher-Daniel Wandrey'
+group: ''

--- a/changelogs/unreleased/2020-03-11-111018-addNewTypeHotfix.yml
+++ b/changelogs/unreleased/2020-03-11-111018-addNewTypeHotfix.yml
@@ -1,4 +1,0 @@
-title: 'add new Type ''Hotfix'''
-type: other
-author: 'Christopher-Daniel Wandrey'
-group: ''

--- a/changelogs/unreleased/2020-03-11-114617-addNewTypeHotfix.yml
+++ b/changelogs/unreleased/2020-03-11-114617-addNewTypeHotfix.yml
@@ -1,0 +1,4 @@
+title: 'Move changelogger type from Types.php to config/changelogger.php'
+type: added
+author: 'Christopher-Daniel Wandrey'
+group: ''

--- a/changelogs/unreleased/2020-03-11-114617-addNewTypeHotfix.yml
+++ b/changelogs/unreleased/2020-03-11-114617-addNewTypeHotfix.yml
@@ -1,4 +1,4 @@
 title: 'Move changelogger type from Types.php to config/changelogger.php'
 type: added
-author: 'Christopher-Daniel Wandrey'
+author: '@cwandrey'
 group: ''

--- a/changelogs/unreleased/2020-05-01-101952-pr-27.yml
+++ b/changelogs/unreleased/2020-05-01-101952-pr-27.yml
@@ -1,0 +1,4 @@
+title: 'Define custom types in .changelogger.yml'
+type: added
+author: ''
+group: ''

--- a/config/changelogger.php
+++ b/config/changelogger.php
@@ -13,4 +13,16 @@ return [
     */
     'directory'  => env('DIRECTORY', getcwd()),
     'unreleased' => env('DIRECTORY', getcwd()) . '/changelogs/unreleased',
+    'types'      => [
+            'New feature'             => 'added',
+            'Bug fix'                 => 'fixed',
+            'Hotfix'                  => 'hotfix',
+            'Feature change'          => 'changed',
+            'New deprecation'         => 'deprecated',
+            'Feature removal'         => 'removed',
+            'Security fix'            => 'security',
+            'Performance improvement' => 'performance',
+            'Other'                   => 'other',
+            'No Changelog'            => 'ignore',
+    ],
 ];

--- a/tests/Feature/Commands/NewChangelogTest.php
+++ b/tests/Feature/Commands/NewChangelogTest.php
@@ -154,7 +154,7 @@ EMPTY;
         $this->withoutGroups();
 
         $this->artisan('new', ['--type' => 'invalid'])
-            ->expectsOutput('No valid type. Use one of the types in config/changelogger.php')
+            ->expectsOutput('No valid type. Use one of the following: added, fixed, hotfix, changed, deprecated, removed, security, performance, other, ignore')
             ->assertExitCode(0);
     }
 

--- a/tests/Feature/Commands/NewChangelogTest.php
+++ b/tests/Feature/Commands/NewChangelogTest.php
@@ -154,7 +154,7 @@ EMPTY;
         $this->withoutGroups();
 
         $this->artisan('new', ['--type' => 'invalid'])
-            ->expectsOutput('No valid type. Use one of the following: added, fixed, hotfix, changed, deprecated, removed, security, performance, other, ignore')
+            ->expectsOutput('No valid type. Use one of the types in config/changelogger.php')
             ->assertExitCode(0);
     }
 

--- a/tests/Feature/Commands/NewChangelogTest.php
+++ b/tests/Feature/Commands/NewChangelogTest.php
@@ -154,7 +154,7 @@ EMPTY;
         $this->withoutGroups();
 
         $this->artisan('new', ['--type' => 'invalid'])
-            ->expectsOutput('No valid type. Use one of the following: added, fixed, changed, deprecated, removed, security, performance, other, ignore')
+            ->expectsOutput('No valid type. Use one of the following: added, fixed, hotfix, changed, deprecated, removed, security, performance, other, ignore')
             ->assertExitCode(0);
     }
 


### PR DESCRIPTION
I once tried to turn the Types into a config. But the config/changelogger.php seemed to make most sense.