### PR TITLE
Prevent writing to changelog if no changes were detected

### DIFF
--- a/app/Commands/ReleaseCommand.php
+++ b/app/Commands/ReleaseCommand.php
@@ -63,8 +63,7 @@ class ReleaseCommand extends Command
     public function handle()
     {
         if ( ! $this->dir->hasChanges()) {
-            $this->build('No changes.');
-            $this->info("Changelog for {$this->argument('tag')} created");
+           $this->info("No Changes -> No Changelog for {$this->argument('tag')} created");
            return;
         }
 

--- a/changelogs/unreleased/2021-10-26-065950-no-changelog.yml
+++ b/changelogs/unreleased/2021-10-26-065950-no-changelog.yml
@@ -1,0 +1,4 @@
+title: 'Using the release command without any changes does not change the CHANGELOG.md file anymore.'
+type: added
+author: ''
+group: ''

--- a/tests/Feature/Commands/ReleaseTest.php
+++ b/tests/Feature/Commands/ReleaseTest.php
@@ -127,24 +127,10 @@ CHANGE;
     {
         File::delete(config('changelogger.directory') . '/CHANGELOG.md');
         $this->artisan('release', ['tag' => 'v1.0.0'])
-            ->expectsOutput('Changelog for v1.0.0 created')
+            ->expectsOutput('No Changes -> No Changelog for v1.0.0 created')
             ->assertExitCode(0);
 
         $this->assertCommandCalled('release', ['tag' => 'v1.0.0']);
-        $this->assertFileExists(config('changelogger.directory') . '/CHANGELOG.md');
-
-        $today = Carbon::now()->format('Y-m-d');
-        $changelog = <<<CHANGE
-<!-- CHANGELOGGER -->
-
-## [v1.0.0] - {$today}
-
-No changes.
-CHANGE;
-
-        $this->assertEquals(
-            $changelog,
-            File::get(config('changelogger.directory') . '/CHANGELOG.md')
-        );
+        $this->assertFileNotExists(config('changelogger.directory') . '/CHANGELOG.md');
     }
 }


### PR DESCRIPTION
When calling `changelogger release 1.0.0` without any changes, no change is made to the `CHANGELOG.md` file now.

I thought about adding a config option for this behaviour but it seems to be a better default for me, and i don't really know when we would write an empty changelog to `CHANGELOG.md`