### PR TITLE
Markdown style

### DIFF
--- a/.changelogger.yml.example
+++ b/.changelogger.yml.example
@@ -12,3 +12,8 @@ groups:
 types:
   added: New Feature
   fixed: Bug fix
+
+# Defines how the generated markdown looks
+markdown:
+    # You can choose between dash (-), asterisks (*) or plus sign (+)
+    listStyle: -

--- a/app/ChangeloggerConfig.php
+++ b/app/ChangeloggerConfig.php
@@ -127,4 +127,15 @@ class ChangeloggerConfig
 
         return $types !== null ? array_flip($types) : $defaultTypes;
     }
+
+    public function getMarkdownOptions(): array {
+        $options = [];
+        $defaultOptions = config('changelogger.markdown');
+        if ($this->config->has('markdown')) {
+            $options = array_merge($defaultOptions, $this->config->get('markdown'));
+        } else {
+            $options = $defaultOptions;
+        }
+        return $options;
+    }
 }

--- a/app/Commands/ReleaseCommand.php
+++ b/app/Commands/ReleaseCommand.php
@@ -129,15 +129,16 @@ CONTENT;
             $count   = $logType->count();
             $changes = sprintf('%d %s', $count, $count === 1 ? 'change' : 'changes');
             $content = "### {$header} ({$changes})\n\n";
+            $markdownOptions = $this->config->getMarkdownOptions();
 
             if ($this->config->hasGroups()) {
                 $content .= $logType->sort(function (Collection $logA,  Collection $logB) {
                     return $this->config->compare($logA->first()->group(), $logB->first()->group());
-                })->map(static function (Collection $group, $name) {
+                })->map(static function (Collection $group, $name) use ($markdownOptions){
                     $content = "#### {$name}\n\n";
 
-                    $content .= $group->map(static function (LogEntry $log) {
-                        $changeEntry = "- {$log->title()}";
+                    $content .= $group->map(static function (LogEntry $log) use ($markdownOptions) {
+                        $changeEntry = "{$markdownOptions['listStyle']} {$log->title()}";
 
                         if ($log->hasAuthor()) {
                             $changeEntry .= " (props {$log->author()})";
@@ -149,8 +150,8 @@ CONTENT;
                     return $content;
                 })->implode("\n\n");
             } else {
-                $content .= $logType->map(static function (LogEntry $log) {
-                    $changeEntry = "- {$log->title()}";
+                $content .= $logType->map(static function (LogEntry $log) use ($markdownOptions) {
+                    $changeEntry = "{$markdownOptions['listStyle']} {$log->title()}";
 
                     if ($log->hasAuthor()) {
                         $changeEntry .= " (props {$log->author()})";

--- a/changelogs/unreleased/2021-10-26-055550-markdown-style.yml
+++ b/changelogs/unreleased/2021-10-26-055550-markdown-style.yml
@@ -1,0 +1,4 @@
+title: 'Markdown list styles can now be configured.'
+type: added
+author: ''
+group: ''

--- a/config/changelogger.php
+++ b/config/changelogger.php
@@ -25,4 +25,7 @@ return [
             'Other'                   => 'other',
             'No Changelog'            => 'ignore',
     ],
+    'markdown'      => [
+        'listStyle' => '-',
+    ],
 ];

--- a/tests/Feature/Commands/ReleaseTest.php
+++ b/tests/Feature/Commands/ReleaseTest.php
@@ -147,4 +147,42 @@ CHANGE;
             File::get(config('changelogger.directory') . '/CHANGELOG.md')
         );
     }
+
+    public function testBuildingChangelogWithMarkdownListStyleStar() : void
+    {
+        File::put(config('changelogger.directory') . '/.changelogger.yml', Yaml::dump(['groups' => ['Wiki'], 'markdown' => ['listStyle' => '*']]));
+        $this->refreshApplication();
+        $this->artisan('new',
+            ['--type' => 'added', '--message' => 'Feature 1 added', '--file' => 'file1', '--group' => 'Wiki'])
+            ->assertExitCode(0);
+
+        $this->assertFileExists(config('changelogger.unreleased') . '/file1.yml');
+
+        $this->artisan('release', ['tag' => 'v1.0.0'])
+            ->expectsOutput('Changelog for v1.0.0 created')
+            ->assertExitCode(0);
+
+        $this->assertCommandCalled('release', ['tag' => 'v1.0.0']);
+        $this->assertFileNotExists(config('changelogger.unreleased') . '/file1.yml');
+        $this->assertFileExists(config('changelogger.directory') . '/CHANGELOG.md');
+
+        $today = Carbon::now()->format('Y-m-d');
+        $changelog = <<<CHANGE
+<!-- CHANGELOGGER -->
+
+## [v1.0.0] - {$today}
+
+### New feature (1 change)
+
+#### Wiki
+
+* Feature 1 added
+
+CHANGE;
+
+        $this->assertEquals(
+            $changelog,
+            File::get(config('changelogger.directory') . '/CHANGELOG.md')
+        );
+    }
 }


### PR DESCRIPTION
With a new config option it is now possible to choose the markdown list style that is used in the `CHANGELOG.md` file.