### PR TITLE
Groups as list

### DIFF
--- a/.changelogger.yml.example
+++ b/.changelogger.yml.example
@@ -17,3 +17,5 @@ types:
 markdown:
     # You can choose between dash (-), asterisks (*) or plus sign (+)
     listStyle: -
+    # if set to true groups are rendered as markdown lists
+    groupsAsList: false

--- a/app/Commands/ReleaseCommand.php
+++ b/app/Commands/ReleaseCommand.php
@@ -134,10 +134,18 @@ CONTENT;
                 $content .= $logType->sort(function (Collection $logA,  Collection $logB) {
                     return $this->config->compare($logA->first()->group(), $logB->first()->group());
                 })->map(static function (Collection $group, $name) use ($markdownOptions){
-                    $content = "#### {$name}\n\n";
+                    if ($markdownOptions['groupsAsList']) {
+                        $content = "{$markdownOptions['listStyle']} **{$name}**\n";
+                    } else {
+                        $content = "#### {$name}\n\n";
+                    }
 
                     $content .= $group->map(static function (LogEntry $log) use ($markdownOptions) {
-                        $changeEntry = "{$markdownOptions['listStyle']} {$log->title()}";
+                        $changeEntry = "";
+                        if ($markdownOptions['groupsAsList']) {
+                            $changeEntry = "  ";
+                        }
+                        $changeEntry .= "{$markdownOptions['listStyle']} {$log->title()}";
 
                         if ($log->hasAuthor()) {
                             $changeEntry .= " (props {$log->author()})";

--- a/changelogs/unreleased/2021-10-26-065817-header-as-list.yml
+++ b/changelogs/unreleased/2021-10-26-065817-header-as-list.yml
@@ -1,0 +1,4 @@
+title: 'Adds a new config option groupsAsList.'
+type: added
+author: ''
+group: ''

--- a/config/changelogger.php
+++ b/config/changelogger.php
@@ -27,5 +27,6 @@ return [
     ],
     'markdown'      => [
         'listStyle' => '-',
+        'groupsAsList' => false,
     ],
 ];

--- a/tests/Feature/Commands/ReleaseTest.php
+++ b/tests/Feature/Commands/ReleaseTest.php
@@ -208,42 +208,4 @@ CHANGE;
             File::get(config('changelogger.directory') . '/CHANGELOG.md')
         );
     }
-
-    public function testBuildingChangelogWithMarkdownListStyleStar() : void
-    {
-        File::put(config('changelogger.directory') . '/.changelogger.yml', Yaml::dump(['groups' => ['Wiki'], 'markdown' => ['listStyle' => '*']]));
-        $this->refreshApplication();
-        $this->artisan('new',
-            ['--type' => 'added', '--message' => 'Feature 1 added', '--file' => 'file1', '--group' => 'Wiki'])
-            ->assertExitCode(0);
-
-        $this->assertFileExists(config('changelogger.unreleased') . '/file1.yml');
-
-        $this->artisan('release', ['tag' => 'v1.0.0'])
-            ->expectsOutput('Changelog for v1.0.0 created')
-            ->assertExitCode(0);
-
-        $this->assertCommandCalled('release', ['tag' => 'v1.0.0']);
-        $this->assertFileNotExists(config('changelogger.unreleased') . '/file1.yml');
-        $this->assertFileExists(config('changelogger.directory') . '/CHANGELOG.md');
-
-        $today = Carbon::now()->format('Y-m-d');
-        $changelog = <<<CHANGE
-<!-- CHANGELOGGER -->
-
-## [v1.0.0] - {$today}
-
-### New feature (1 change)
-
-#### Wiki
-
-* Feature 1 added
-
-CHANGE;
-
-        $this->assertEquals(
-            $changelog,
-            File::get(config('changelogger.directory') . '/CHANGELOG.md')
-        );
-    }
 }

--- a/tests/Feature/Commands/ReleaseTest.php
+++ b/tests/Feature/Commands/ReleaseTest.php
@@ -171,4 +171,42 @@ CHANGE;
             File::get(config('changelogger.directory') . '/CHANGELOG.md')
         );
     }
+
+    public function testBuildingChangelogWithMarkdownListStyleStar() : void
+    {
+        File::put(config('changelogger.directory') . '/.changelogger.yml', Yaml::dump(['groups' => ['Wiki'], 'markdown' => ['listStyle' => '*']]));
+        $this->refreshApplication();
+        $this->artisan('new',
+            ['--type' => 'added', '--message' => 'Feature 1 added', '--file' => 'file1', '--group' => 'Wiki'])
+            ->assertExitCode(0);
+
+        $this->assertFileExists(config('changelogger.unreleased') . '/file1.yml');
+
+        $this->artisan('release', ['tag' => 'v1.0.0'])
+            ->expectsOutput('Changelog for v1.0.0 created')
+            ->assertExitCode(0);
+
+        $this->assertCommandCalled('release', ['tag' => 'v1.0.0']);
+        $this->assertFileNotExists(config('changelogger.unreleased') . '/file1.yml');
+        $this->assertFileExists(config('changelogger.directory') . '/CHANGELOG.md');
+
+        $today = Carbon::now()->format('Y-m-d');
+        $changelog = <<<CHANGE
+<!-- CHANGELOGGER -->
+
+## [v1.0.0] - {$today}
+
+### New feature (1 change)
+
+#### Wiki
+
+* Feature 1 added
+
+CHANGE;
+
+        $this->assertEquals(
+            $changelog,
+            File::get(config('changelogger.directory') . '/CHANGELOG.md')
+        );
+    }
 }

--- a/tests/Feature/Commands/ReleaseTest.php
+++ b/tests/Feature/Commands/ReleaseTest.php
@@ -172,6 +172,43 @@ CHANGE;
         );
     }
 
+    public function testBuildingChangelogWithMarkdownGroupsAsList() : void
+    {
+        File::put(config('changelogger.directory') . '/.changelogger.yml', Yaml::dump(['groups' => ['Wiki'], 'markdown' => ['groupsAsList' => true]]));
+        $this->refreshApplication();
+        $this->artisan('new',
+            ['--type' => 'added', '--message' => 'Feature 1 added', '--file' => 'file1', '--group' => 'Wiki'])
+            ->assertExitCode(0);
+
+        $this->assertFileExists(config('changelogger.unreleased') . '/file1.yml');
+
+        $this->artisan('release', ['tag' => 'v1.0.0'])
+            ->expectsOutput('Changelog for v1.0.0 created')
+            ->assertExitCode(0);
+
+        $this->assertCommandCalled('release', ['tag' => 'v1.0.0']);
+        $this->assertFileNotExists(config('changelogger.unreleased') . '/file1.yml');
+        $this->assertFileExists(config('changelogger.directory') . '/CHANGELOG.md');
+
+        $today = Carbon::now()->format('Y-m-d');
+        $changelog = <<<CHANGE
+<!-- CHANGELOGGER -->
+
+## [v1.0.0] - {$today}
+
+### New feature (1 change)
+
+- **Wiki**
+  - Feature 1 added
+
+CHANGE;
+
+        $this->assertEquals(
+            $changelog,
+            File::get(config('changelogger.directory') . '/CHANGELOG.md')
+        );
+    }
+
     public function testBuildingChangelogWithMarkdownListStyleStar() : void
     {
         File::put(config('changelogger.directory') . '/.changelogger.yml', Yaml::dump(['groups' => ['Wiki'], 'markdown' => ['listStyle' => '*']]));


### PR DESCRIPTION
Adds a new config option `groupsAsList`.

If set to true the groups are rendered as lists and changelog entries are rendered as sublists.

Example: 


```
<!-- CHANGELOGGER -->
## [v1.0.0] - {$today}
### New feature (1 change)
- **Wiki**
  - Feature 1 added
```

This merge request depends on https://github.com/churchtools/changelogger/pull/57 on should be merged after.