### PR TITLE
Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 FROM php:8.1-cli-alpine
 
-COPY . /changelogger
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6') { echo 'Installer verified'.PHP_EOL; } else { echo 'Installer corrupt'.PHP_EOL; unlink('composer-setup.php'); exit(1); }" \
-    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.8.6 \
-    && php -r "unlink('composer-setup.php');"
-RUN (cd /changelogger && composer install)
-RUN ln -s /changelogger/changelogger /usr/local/bin/changelogger \
+COPY ./builds/changelogger /changelogger/builds/changelogger
+COPY ./LICENSE /changelogger/LICENSE
+RUN ln -s /changelogger/builds/changelogger /usr/local/bin/changelogger \
     && mkdir /app
 WORKDIR /app
 VOLUME ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM php:8.1-cli-alpine
+
+COPY . /changelogger
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6') { echo 'Installer verified'.PHP_EOL; } else { echo 'Installer corrupt'.PHP_EOL; unlink('composer-setup.php'); exit(1); }" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.8.6 \
+    && php -r "unlink('composer-setup.php');"
+RUN (cd /changelogger && composer install)
+RUN ln -s /changelogger/changelogger /usr/local/bin/changelogger \
+    && mkdir /app
+WORKDIR /app
+VOLUME ["/app"]
+CMD ["changelogger", "new"]

--- a/README.md
+++ b/README.md
@@ -34,10 +34,24 @@ You can require the package as a dev-dependency
 composer require --dev churchtools/changelogger
 ```
 
-or install it globally.
+or install it globally
 
 ```bash
 composer global require churchtools/changelogger
+```
+
+or build a docker image.
+
+```bash
+composer run docker:build
+```
+
+Then add this to e.g. your `~/.profile`:
+
+```bash
+changelogger () {
+  docker run --rm -it -v $(PWD):/app changelogger changelogger $@
+}
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Then add this to e.g. your `~/.profile`:
 
 ```bash
 changelogger () {
-  docker run --rm -it -v $(PWD):/app changelogger changelogger $@
+  docker run --rm -it -v $(PWD):/app churchtools/changelogger changelogger $@
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "post-create-project-cmd": [
             "@php application app:rename"
         ],
-        "test": "phpunit --colors=always --testdox"
+        "test": "phpunit --colors=always --testdox",
+        "docker:build": "docker build -t changelogger ."
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
             "@php application app:rename"
         ],
         "test": "phpunit --colors=always --testdox",
-        "docker:build": "docker build -t changelogger ."
+        "docker:build": "docker build -t churchtools/changelogger ."
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
I prefer to use this tool via Docker for historical reasons. (conflicting PHP versions etc.)
Docker support would also make this tool interesting for devs that don't use PHP.
If you push this to Docker Hub, installation is quite simple:

```bash
# e.g. ~/.zprofile
changelogger () {
  docker run --rm -it -v $(PWD):/app churchtools/changelogger changelogger $@
}
```

In this case I suggest updating the README.md as follows:

...
or run via docker.

```bash
# e.g. ~/.profile
changelogger () {
  docker run --rm -it -v $(PWD):/app churchtools/changelogger changelogger $@
}
```
