### PR TITLE
Show specific release

### DIFF
--- a/app/ChangelogMarkdownGenerator.php
+++ b/app/ChangelogMarkdownGenerator.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App;
+
+use Illuminate\Support\Collection;
+
+class ChangelogMarkdownGenerator
+{
+
+    /** @var Types */
+    private $types;
+
+    /** @var ChangeloggerConfig */
+    private $config;
+
+
+    public function __construct(Types $types, ChangeloggerConfig $config)
+    {
+        $this->types = $types;
+        $this->config = $config;
+    }
+
+
+    public function generate(Collection $changes) : string
+    {
+        $groupByFunctions[] = static function (LogEntry $logEntry) {
+            return $logEntry->type();
+        };
+
+        if ($this->config->hasGroups()) {
+            $groupByFunctions[] = static function (LogEntry $logEntry) {
+                return $logEntry->group();
+            };
+        }
+
+        $changes = $changes->groupBy($groupByFunctions)->filter(static function (Collection $logType, $key) {
+            return $key !== 'ignore';
+        })->sort();
+
+        return $changes->map(function (Collection $logType, $key) {
+            $header  = $this->types->getName($key);
+            $count   = $logType->count();
+            $changes = sprintf('%d %s', $count, $count === 1 ? 'change' : 'changes');
+            $content = "### {$header} ({$changes})\n\n";
+            $markdownOptions = $this->config->getMarkdownOptions();
+
+            if ($this->config->hasGroups()) {
+                $content .= $logType->sort(function (Collection $logA,  Collection $logB) {
+                    return $this->config->compare($logA->first()->group(), $logB->first()->group());
+                })->map(static function (Collection $group, $name) use ($markdownOptions){
+                    if ($markdownOptions['groupsAsList']) {
+                        $content = "{$markdownOptions['listStyle']} **{$name}**\n";
+                    } else {
+                        $content = "#### {$name}\n\n";
+                    }
+
+                    $content .= $group->map(static function (LogEntry $log) use ($markdownOptions) {
+                        $changeEntry = "";
+                        if ($markdownOptions['groupsAsList']) {
+                            $changeEntry = "  ";
+                        }
+                        $changeEntry .= "{$markdownOptions['listStyle']} {$log->title()}";
+
+                        if ($log->hasAuthor()) {
+                            $changeEntry .= " (props {$log->author()})";
+                        }
+
+                        return $changeEntry;
+                    })->implode("\n");
+
+                    return $content;
+                })->implode("\n\n");
+            } else {
+                $content .= $logType->map(static function (LogEntry $log) use ($markdownOptions) {
+                    $changeEntry = "{$markdownOptions['listStyle']} {$log->title()}";
+
+                    if ($log->hasAuthor()) {
+                        $changeEntry .= " (props {$log->author()})";
+                    }
+
+                    return $changeEntry;
+                })->implode("\n");
+
+            }
+
+            $content .= "\n";
+            return $content;
+        })->implode("\n");
+    }
+}

--- a/app/Commands/ReleaseCommand.php
+++ b/app/Commands/ReleaseCommand.php
@@ -2,12 +2,10 @@
 
 namespace App\Commands;
 
-use App\ChangeloggerConfig;
+use App\ChangelogMarkdownGenerator;
 use App\ChangesDirectory;
 use App\LogEntry;
-use App\Types;
 use Carbon\Carbon;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use LaravelZero\Framework\Commands\Command;
 
@@ -31,27 +29,22 @@ class ReleaseCommand extends Command
     /** @var ChangesDirectory */
     private $dir;
 
-    /** @var Types */
-    private $types;
-
-    /** @var ChangeloggerConfigConfig */
-    private $config;
+    /** @var ChangelogMarkdownGenerator */
+    private $markdownGenerator;
 
 
     /**
      * BuildChangelog constructor.
      *
-     * @param ChangesDirectory   $dir
-     * @param Types              $types
-     * @param ChangeloggerConfig $config
+     * @param ChangesDirectory          $dir
+     * @param ChangelogMarkdownGenerator $markdownGenerator
      */
-    public function __construct(ChangesDirectory $dir, Types $types, ChangeloggerConfig $config)
+    public function __construct(ChangesDirectory $dir, ChangelogMarkdownGenerator $markdownGenerator)
     {
         parent::__construct();
-        $this->dir   = $dir;
+        $this->dir = $dir;
         $this->dir->init();
-        $this->types = $types;
-        $this->config = $config;
+        $this->markdownGenerator = $markdownGenerator;
     }
 
 
@@ -73,7 +66,7 @@ class ReleaseCommand extends Command
             $changes->push(LogEntry::parse($file));
         }
 
-        $content = $this->generateContent($changes);
+        $content = $this->markdownGenerator->generate($changes);
         $this->build($content);
 
         $this->info("Changelog for {$this->argument('tag')} created");
@@ -108,70 +101,4 @@ CONTENT;
     }
 
 
-    private function generateContent(Collection $changes) : string
-    {
-        $groupByFunctions[] = static function (LogEntry $logEntry) {
-            return $logEntry->type();
-        };
-
-        if ($this->config->hasGroups()) {
-            $groupByFunctions[] = static function (LogEntry $logEntry) {
-                return $logEntry->group();
-            };
-        }
-
-        $changes = $changes->groupBy($groupByFunctions)->filter(static function (Collection $logType, $key) {
-            return $key !== 'ignore';
-        })->sort();
-
-        return $changes->map(function (Collection $logType, $key) {
-            $header  = $this->types->getName($key);
-            $count   = $logType->count();
-            $changes = sprintf('%d %s', $count, $count === 1 ? 'change' : 'changes');
-            $content = "### {$header} ({$changes})\n\n";
-            $markdownOptions = $this->config->getMarkdownOptions();
-
-            if ($this->config->hasGroups()) {
-                $content .= $logType->sort(function (Collection $logA,  Collection $logB) {
-                    return $this->config->compare($logA->first()->group(), $logB->first()->group());
-                })->map(static function (Collection $group, $name) use ($markdownOptions){
-                    if ($markdownOptions['groupsAsList']) {
-                        $content = "{$markdownOptions['listStyle']} **{$name}**\n";
-                    } else {
-                        $content = "#### {$name}\n\n";
-                    }
-
-                    $content .= $group->map(static function (LogEntry $log) use ($markdownOptions) {
-                        $changeEntry = "";
-                        if ($markdownOptions['groupsAsList']) {
-                            $changeEntry = "  ";
-                        }
-                        $changeEntry .= "{$markdownOptions['listStyle']} {$log->title()}";
-
-                        if ($log->hasAuthor()) {
-                            $changeEntry .= " (props {$log->author()})";
-                        }
-
-                        return $changeEntry;
-                    })->implode("\n");
-
-                    return $content;
-                })->implode("\n\n");
-            } else {
-                $content .= $logType->map(static function (LogEntry $log) use ($markdownOptions) {
-                    $changeEntry = "{$markdownOptions['listStyle']} {$log->title()}";
-
-                    if ($log->hasAuthor()) {
-                        $changeEntry .= " (props {$log->author()})";
-                    }
-
-                    return $changeEntry;
-                })->implode("\n");
-
-            }
-
-            $content .= "\n";
-            return $content;
-        })->implode("\n");
-    }
 }

--- a/app/Commands/ShowCommand.php
+++ b/app/Commands/ShowCommand.php
@@ -5,7 +5,9 @@ namespace App\Commands;
 use App\ChangeloggerConfig;
 use App\ChangesDirectory;
 use App\LogEntry;
+use App\Types;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
 use LaravelZero\Framework\Commands\Command;
 
 class ShowCommand extends Command
@@ -16,17 +18,20 @@ class ShowCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'show';
+    protected $signature = 'show {version? : Released version to show}';
 
     /**
      * The description of the command.
      *
      * @var string
      */
-    protected $description = 'Show unreleased changes';
+    protected $description = 'Show unreleased or released changes';
 
     /** @var ChangesDirectory */
     private $dir;
+
+    /** @var Types */
+    private $types;
 
     /** @var ChangeloggerConfig */
     private $config;
@@ -36,13 +41,15 @@ class ShowCommand extends Command
      * ShowCommand constructor.
      *
      * @param ChangesDirectory   $dir
+     * @param Types              $types
      * @param ChangeloggerConfig $config
      */
-    public function __construct(ChangesDirectory $dir, ChangeloggerConfig $config)
+    public function __construct(ChangesDirectory $dir, Types $types, ChangeloggerConfig $config)
     {
         parent::__construct();
-        $this->dir = $dir;
+        $this->dir   = $dir;
         $this->dir->init();
+        $this->types = $types;
         $this->config = $config;
     }
 
@@ -54,60 +61,129 @@ class ShowCommand extends Command
      */
     public function handle()
     {
-        $this->table($this->tableHeaders(), $this->tableRows());
+        if ($this->argument('version') !== null) {
+            return $this->showReleasedVersion($this->argument('version'));
+        }
+
+        $this->line($this->generateUnreleasedMarkdown());
+        return 0;
     }
 
 
-    private function tableHeaders() : array
+    private function generateUnreleasedMarkdown() : string
     {
-        if ($this->config->hasGroups()) {
-            return ['No.', 'Type', 'Group', 'Log', 'Author'];
-        }
-
-        return ['No.', 'Type', 'Log', 'Author'];
-    }
-
-
-    private function tableRows() : array
-    {
-        $hasGroups          = $this->config->hasGroups();
-        $groupByFunctions[] = static function (LogEntry $logEntry) {
-            return $logEntry->type();
-        };
-
-        if ($hasGroups) {
-            $groupByFunctions[] = static function (LogEntry $logEntry) {
-                return $logEntry->group();
-            };
-        }
-
         $changes = collect();
         foreach ($this->dir->getAll() as $file) {
             $changes->push(LogEntry::parse($file));
         }
 
-        return $changes->groupBy($groupByFunctions)->filter(static function (
-                Collection $logType,
-                $key
-            ) {
-                return $key !== 'ignore';
-            })->sort()->flatten()->map(static function (LogEntry $log, $key) use ($hasGroups) {
-                if ($hasGroups) {
-                    return [
-                        $key + 1,
-                        $log->type(),
-                        $log->group(),
-                        $log->title(),
-                        $log->author()
-                    ];
-                }
+        return $this->generateContent($changes);
+    }
 
-                return [
-                    $key + 1,
-                    $log->type(),
-                    $log->title(),
-                    $log->author()
-                ];
-            })->toArray();
+
+    private function generateContent(Collection $changes) : string
+    {
+        $groupByFunctions[] = static function (LogEntry $logEntry) {
+            return $logEntry->type();
+        };
+
+        if ($this->config->hasGroups()) {
+            $groupByFunctions[] = static function (LogEntry $logEntry) {
+                return $logEntry->group();
+            };
+        }
+
+        $changes = $changes->groupBy($groupByFunctions)->filter(static function (Collection $logType, $key) {
+            return $key !== 'ignore';
+        })->sort();
+
+        return $changes->map(function (Collection $logType, $key) {
+            $header  = $this->types->getName($key);
+            $count   = $logType->count();
+            $changes = sprintf('%d %s', $count, $count === 1 ? 'change' : 'changes');
+            $content = "### {$header} ({$changes})\n\n";
+            $markdownOptions = $this->config->getMarkdownOptions();
+
+            if ($this->config->hasGroups()) {
+                $content .= $logType->sort(function (Collection $logA,  Collection $logB) {
+                    return $this->config->compare($logA->first()->group(), $logB->first()->group());
+                })->map(static function (Collection $group, $name) use ($markdownOptions){
+                    if ($markdownOptions['groupsAsList']) {
+                        $content = "{$markdownOptions['listStyle']} **{$name}**\n";
+                    } else {
+                        $content = "#### {$name}\n\n";
+                    }
+
+                    $content .= $group->map(static function (LogEntry $log) use ($markdownOptions) {
+                        $changeEntry = "";
+                        if ($markdownOptions['groupsAsList']) {
+                            $changeEntry = "  ";
+                        }
+                        $changeEntry .= "{$markdownOptions['listStyle']} {$log->title()}";
+
+                        if ($log->hasAuthor()) {
+                            $changeEntry .= " (props {$log->author()})";
+                        }
+
+                        return $changeEntry;
+                    })->implode("\n");
+
+                    return $content;
+                })->implode("\n\n");
+            } else {
+                $content .= $logType->map(static function (LogEntry $log) use ($markdownOptions) {
+                    $changeEntry = "{$markdownOptions['listStyle']} {$log->title()}";
+
+                    if ($log->hasAuthor()) {
+                        $changeEntry .= " (props {$log->author()})";
+                    }
+
+                    return $changeEntry;
+                })->implode("\n");
+
+            }
+
+            $content .= "\n";
+            return $content;
+        })->implode("\n");
+    }
+
+
+    private function showReleasedVersion(string $version) : int
+    {
+        $changelogPath = config('changelogger.directory') . '/CHANGELOG.md';
+
+        if ( ! File::exists($changelogPath)) {
+            return $this->releaseNotFound($version);
+        }
+
+        $releaseSection = $this->findReleaseSection(File::get($changelogPath), $version);
+
+        if ($releaseSection === null) {
+            return $this->releaseNotFound($version);
+        }
+
+        $this->line($releaseSection);
+        return 0;
+    }
+
+
+    private function findReleaseSection(string $changelog, string $version) : ?string
+    {
+        $quotedVersion = preg_quote($version, '/');
+        $pattern = "/^## \[{$quotedVersion}\].*?(?=\n## \[|\z)/ms";
+
+        if (preg_match($pattern, $changelog, $matches) !== 1) {
+            return null;
+        }
+
+        return rtrim($matches[0]);
+    }
+
+
+    private function releaseNotFound(string $version) : int
+    {
+        $this->error("Error: Release \"{$version}\" was not found in CHANGELOG.md.");
+        return 1;
     }
 }

--- a/app/Commands/ShowCommand.php
+++ b/app/Commands/ShowCommand.php
@@ -2,11 +2,9 @@
 
 namespace App\Commands;
 
-use App\ChangeloggerConfig;
+use App\ChangelogMarkdownGenerator;
 use App\ChangesDirectory;
 use App\LogEntry;
-use App\Types;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use LaravelZero\Framework\Commands\Command;
 
@@ -30,27 +28,22 @@ class ShowCommand extends Command
     /** @var ChangesDirectory */
     private $dir;
 
-    /** @var Types */
-    private $types;
-
-    /** @var ChangeloggerConfig */
-    private $config;
+    /** @var ChangelogMarkdownGenerator */
+    private $markdownGenerator;
 
 
     /**
      * ShowCommand constructor.
      *
-     * @param ChangesDirectory   $dir
-     * @param Types              $types
-     * @param ChangeloggerConfig $config
+     * @param ChangesDirectory          $dir
+     * @param ChangelogMarkdownGenerator $markdownGenerator
      */
-    public function __construct(ChangesDirectory $dir, Types $types, ChangeloggerConfig $config)
+    public function __construct(ChangesDirectory $dir, ChangelogMarkdownGenerator $markdownGenerator)
     {
         parent::__construct();
-        $this->dir   = $dir;
+        $this->dir = $dir;
         $this->dir->init();
-        $this->types = $types;
-        $this->config = $config;
+        $this->markdownGenerator = $markdownGenerator;
     }
 
 
@@ -77,75 +70,7 @@ class ShowCommand extends Command
             $changes->push(LogEntry::parse($file));
         }
 
-        return $this->generateContent($changes);
-    }
-
-
-    private function generateContent(Collection $changes) : string
-    {
-        $groupByFunctions[] = static function (LogEntry $logEntry) {
-            return $logEntry->type();
-        };
-
-        if ($this->config->hasGroups()) {
-            $groupByFunctions[] = static function (LogEntry $logEntry) {
-                return $logEntry->group();
-            };
-        }
-
-        $changes = $changes->groupBy($groupByFunctions)->filter(static function (Collection $logType, $key) {
-            return $key !== 'ignore';
-        })->sort();
-
-        return $changes->map(function (Collection $logType, $key) {
-            $header  = $this->types->getName($key);
-            $count   = $logType->count();
-            $changes = sprintf('%d %s', $count, $count === 1 ? 'change' : 'changes');
-            $content = "### {$header} ({$changes})\n\n";
-            $markdownOptions = $this->config->getMarkdownOptions();
-
-            if ($this->config->hasGroups()) {
-                $content .= $logType->sort(function (Collection $logA,  Collection $logB) {
-                    return $this->config->compare($logA->first()->group(), $logB->first()->group());
-                })->map(static function (Collection $group, $name) use ($markdownOptions){
-                    if ($markdownOptions['groupsAsList']) {
-                        $content = "{$markdownOptions['listStyle']} **{$name}**\n";
-                    } else {
-                        $content = "#### {$name}\n\n";
-                    }
-
-                    $content .= $group->map(static function (LogEntry $log) use ($markdownOptions) {
-                        $changeEntry = "";
-                        if ($markdownOptions['groupsAsList']) {
-                            $changeEntry = "  ";
-                        }
-                        $changeEntry .= "{$markdownOptions['listStyle']} {$log->title()}";
-
-                        if ($log->hasAuthor()) {
-                            $changeEntry .= " (props {$log->author()})";
-                        }
-
-                        return $changeEntry;
-                    })->implode("\n");
-
-                    return $content;
-                })->implode("\n\n");
-            } else {
-                $content .= $logType->map(static function (LogEntry $log) use ($markdownOptions) {
-                    $changeEntry = "{$markdownOptions['listStyle']} {$log->title()}";
-
-                    if ($log->hasAuthor()) {
-                        $changeEntry .= " (props {$log->author()})";
-                    }
-
-                    return $changeEntry;
-                })->implode("\n");
-
-            }
-
-            $content .= "\n";
-            return $content;
-        })->implode("\n");
+        return $this->markdownGenerator->generate($changes);
     }
 
 

--- a/changelogs/unreleased/2026-05-26-082545-issue-84-show-specific-release.yml
+++ b/changelogs/unreleased/2026-05-26-082545-issue-84-show-specific-release.yml
@@ -1,0 +1,4 @@
+title: 'Show a specific released changelog section with the show command'
+type: added
+author: ''
+group: ''

--- a/changelogs/unreleased/2026-05-26-084409-issue-84-show-specific-release.yml
+++ b/changelogs/unreleased/2026-05-26-084409-issue-84-show-specific-release.yml
@@ -1,0 +1,4 @@
+title: 'show command lists unreleased changes as markdown and not as table anymore.'
+type: changed
+author: ''
+group: ''

--- a/tests/Feature/Commands/ShowTest.php
+++ b/tests/Feature/Commands/ShowTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+
+    public function tearDown(): void
+    {
+        File::delete(config('changelogger.directory') . '/CHANGELOG.md');
+        parent::tearDown();
+    }
+
+
+    public function testShowingUnreleasedChangesAsMarkdown() : void
+    {
+        $this->artisan('new',
+            ['--type' => 'added', '--message' => 'Feature added', '--file' => 'file1'])
+            ->assertExitCode(0);
+        $this->artisan('new',
+            ['--type' => 'fixed', '--message' => 'Bug fixed', '--file' => 'file2'])
+            ->assertExitCode(0);
+
+        $this->artisan('show')
+            ->expectsOutputToContain(<<<CHANGE
+### Bug fix (1 change)
+
+- Bug fixed
+
+### New feature (1 change)
+
+- Feature added
+CHANGE)
+            ->assertExitCode(0);
+    }
+
+
+    public function testShowingSpecificReleasedVersion() : void
+    {
+        File::put(config('changelogger.directory') . '/CHANGELOG.md', <<<CHANGE
+# Changelog
+
+<!-- CHANGELOGGER -->
+
+## [v1.1.0] - 2026-05-26
+
+### New feature (1 change)
+
+- Newer feature
+
+
+## [v1.0.0] - 2026-05-25
+
+### Bug fix (1 change)
+
+- Bug fixed
+
+
+## [v0.9.0] - 2026-05-24
+
+### Other (1 change)
+
+- Older change
+CHANGE);
+
+        $this->artisan('show', ['version' => 'v1.0.0'])
+            ->expectsOutput(<<<CHANGE
+## [v1.0.0] - 2026-05-25
+
+### Bug fix (1 change)
+
+- Bug fixed
+CHANGE)
+            ->assertExitCode(0);
+    }
+
+
+    public function testShowingMissingReleasedVersionFails() : void
+    {
+        File::put(config('changelogger.directory') . '/CHANGELOG.md', <<<CHANGE
+# Changelog
+
+<!-- CHANGELOGGER -->
+
+## [v1.0.0] - 2026-05-25
+
+### Bug fix (1 change)
+
+- Bug fixed
+CHANGE);
+
+        $this->artisan('show', ['version' => 'v1.0'])
+            ->expectsOutput('Error: Release "v1.0" was not found in CHANGELOG.md.')
+            ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
## Summary
- output unreleased changes as Markdown from the show command
- add optional version argument to print one exact release section from CHANGELOG.md
- return a non-zero error when the requested release is missing

Closes #84

## Tests
- vendor/bin/phpunit tests/Feature/Commands/ShowTest.php --colors=always